### PR TITLE
update: テスト実行前にtasks.jsonを削除

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,21 +1,26 @@
 'use strict';
-const todo = require('./index.js');
-const assert = require('assert');
 
-// todo と list のテスト
-todo.todo('ノートを買う');
-todo.todo('鉛筆を買う');
-assert.deepEqual(todo.list(), ['ノートを買う', '鉛筆を買う']);
+const fs = require('fs');
 
-// done と donelist のテスト
-todo.done('鉛筆を買う');
-assert.deepEqual(todo.list(), ['ノートを買う']);
-assert.deepEqual(todo.donelist(), ['鉛筆を買う']);
+fs.unlink('./tasks.json', (err) => {
+    const todo = require('./index.js');
+    const assert = require('assert');
 
-// del のテスト
-todo.del('ノートを買う');
-todo.del('鉛筆を買う');
-assert.deepEqual(todo.list(), []);
-assert.deepEqual(todo.donelist(), []);
+    // todo と list のテスト
+    todo.todo('ノートを買う');
+    todo.todo('鉛筆を買う');
+    assert.deepEqual(todo.list(), ['ノートを買う', '鉛筆を買う']);
 
-console.log('テストが正常に完了しました');
+    // done と donelist のテスト
+    todo.done('鉛筆を買う');
+    assert.deepEqual(todo.list(), ['ノートを買う']);
+    assert.deepEqual(todo.donelist(), ['鉛筆を買う']);
+
+    // del のテスト
+    todo.del('ノートを買う');
+    todo.del('鉛筆を買う');
+    assert.deepEqual(todo.list(), []);
+    assert.deepEqual(todo.donelist(), []);
+
+    console.log('テストが正常に完了しました');
+});


### PR DESCRIPTION
tasks.jsonが存在する場合、テスト実行時に読み込んでしまうため、テストに失敗する可能性があった。なので、テスト実行前にtasks.jsonを削除するように実装。