### PR TITLE
tasks.json を削除してからテストを実行するように実装

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,21 +1,26 @@
 'use strict';
-const todo = require('./index.js');
 const assert = require('assert');
 
-// todo と list のテスト
-todo.todo('ノートを買う');
-todo.todo('鉛筆を買う');
-assert.deepEqual(todo.list(), ['ノートを買う', '鉛筆を買う']);
+// テストの前に永続化されているファイルを消す
+const fs = require('fs');
+fs.unlink('./tasks.json', err => {
+    const todo = require('./index.js');
 
-// done と donelist のテスト
-todo.done('鉛筆を買う');
-assert.deepEqual(todo.list(), ['ノートを買う']);
-assert.deepEqual(todo.donelist(), ['鉛筆を買う']);
+    // add と list のテスト
+    todo.add('ノートを買う');
+    todo.add('鉛筆を買う');
+    assert.deepStrictEqual(todo.list(), ['ノートを買う', '鉛筆を買う']);
 
-// del のテスト
-todo.del('ノートを買う');
-todo.del('鉛筆を買う');
-assert.deepEqual(todo.list(), []);
-assert.deepEqual(todo.donelist(), []);
+    // done と donelist のテスト
+    todo.done('鉛筆を買う');
+    assert.deepStrictEqual(todo.list(), ['ノートを買う']);
+    assert.deepStrictEqual(todo.donelist(), ['鉛筆を買う']);
 
-console.log('テストが正常に完了しました');
+    // del のテスト
+    todo.del('ノートを買う');
+    todo.del('鉛筆を買う');
+    assert.deepStrictEqual(todo.list(), []);
+    assert.deepStrictEqual(todo.donelist(), []);
+
+    console.log('テストが正常に完了しました');
+});


### PR DESCRIPTION
練習問題なのでマージは不要です。
 テストの際に存在する tasks.json を読み込んでしまいテストが失敗してしまう可能性があるため、 tasks.json を削除してからテストを実行するように実装しました。